### PR TITLE
Allow attributes to specify default of Proc

### DIFF
--- a/lib/schema/controls/schema.rb
+++ b/lib/schema/controls/schema.rb
@@ -56,6 +56,13 @@ module Schema
           include ::Schema
           attribute :some_attribute, default: 'some default value'
         end
+
+        module Proc
+          class Example
+            include ::Schema
+            attribute :some_attribute, default: proc { 'some default value' }
+          end
+        end
       end
 
       module Typed

--- a/lib/schema/schema.rb
+++ b/lib/schema/schema.rb
@@ -30,7 +30,9 @@ module Schema
       end
 
       initialize_value = nil
-      unless default.nil?
+      if default.is_a? Proc
+        initialize_value = default
+      elsif !default.nil?
         initialize_value = proc { default }
       end
 

--- a/test/bench/schema/default_attribute_value.rb
+++ b/test/bench/schema/default_attribute_value.rb
@@ -2,10 +2,20 @@ require_relative '../bench_init'
 
 context "Default Attribute Value" do
   context "Attribute With Default Value Declaration" do
-    example = Schema::Controls::Schema::DefaultValue::Example.new
+    context do
+      example = Schema::Controls::Schema::DefaultValue::Example.new
 
-    test "Has a default value" do
-      assert(example.some_attribute == 'some default value')
+      test "Has a default value" do
+        assert(example.some_attribute == 'some default value')
+      end
+    end
+
+    context "Default Value Is Proc" do
+      example = Schema::Controls::Schema::DefaultValue::Proc::Example.new
+
+      test "Has a default value set by executing proc" do
+        assert(example.some_attribute == 'some default value')
+      end
     end
   end
 


### PR DESCRIPTION
Consider:

```ruby
class SomeStructure
  include Schema

  attribute :some_array, default: []
end
```

In this case, _every instance_ of `SomeStructure` will receive the exact same array as the default value from the `some_array` attribute:

```ruby
structure_1 = SomeStructure.new
structure_2 = SomeStructure.new

# Array 2 is an exact copy of array 1. This is effectively global state!
assert structure_1.some_array.object_id == structure2.some_array.object_id
```

To combat this, some attributes need their default supplied as a proc, so that the proc can be called on demand. Fortunately, the `attribute` library already accounts for this. This pull request brings that functionality to the `default` argument of the attribute macro:

```ruby
class SomeStructure
  attribute :some_array, default: proc { [] }
end

structure_1 = SomeStructure.new
structure_2 = SomeStructure.new

# Array 2 is no longer an exact copy of array 1.
refute structure_1.some_array.object_id == structure2.some_array.object_id
```
