### PR TITLE
Schema equality allows control and compare schemas to have different attributes

### DIFF
--- a/lib/schema/schema.rb
+++ b/lib/schema/schema.rb
@@ -184,6 +184,12 @@ module Schema
   end
 
   def ==(other, attributes_names=nil, ignore_class: nil)
+    ignore_class ||= false
+
+    if not ignore_class
+      return false if self.class != other.class
+    end
+
     comparison = Compare.(self, other, attributes_names)
 
     different = comparison.different?(ignore_class: ignore_class)

--- a/test/automated/schema/equality/equality.rb
+++ b/test/automated/schema/equality/equality.rb
@@ -32,6 +32,14 @@ context "Equality" do
           refute(control == compare)
         end
       end
+
+      context "Attributes are different and classes are not equal" do
+        compare = Schema::Controls::Schema::Random.example
+
+        test "Schemas are not equal" do
+          refute(control == compare)
+        end
+      end
     end
   end
 end

--- a/test/automated/schema/equality/ignore_class.rb
+++ b/test/automated/schema/equality/ignore_class.rb
@@ -3,11 +3,35 @@ require_relative '../../automated_init'
 context "Equality" do
   context "Class is ignored" do
     context "Classes are not equal" do
-      control = Schema::Controls::Schema.example
-      compare = Schema::Controls::Schema.other_example
+      context "Attributes are the same" do
+        control = Schema::Controls::Schema.example
+        compare = Schema::Controls::Schema.other_example
 
-      test "Schemas are equal" do
-        assert(control.eql?(compare, ignore_class: true))
+        test "Schemas are equal" do
+          assert(control.eql?(compare, ignore_class: true))
+        end
+      end
+
+      context "Attributes have different values" do
+        control = Schema::Controls::Schema.example
+        compare = Schema::Controls::Schema.other_example
+
+        compare.some_attribute = Schema::Controls::Random.example
+
+        test "Schemas are not equal" do
+          refute(control.eql?(compare, ignore_class: true))
+        end
+      end
+
+      context "Attributes are different" do
+        control = Schema::Controls::Schema.example
+        compare = Schema::Controls::Schema::Random.example
+
+        test "Is an error" do
+          assert_raises(Schema::Compare::Comparison::Error) do
+            control.eql?(compare, ignore_class: true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR is about schema equality (`Schema#==`), but before it can be explained, a bit of background on `Schema::Compare` is necessary, since schema equality is implemented in terms of schema comparison.

Schema::Compare is designed to be able to compare schemas of different classes. Since both the control schema and the comparison schema may not share the same attributes (they are different schemas, after all), an error is raised if the compare schema is missing any attribute that's being compared. So, if the control schema has the attributes `some_attribute` and `other_attribute`, Schema::Compare will raise an error unless the compare schema has both `some_attribute` and `other_attribute`.

```ruby
class SomeSchema
  include Schema

  attribute :some_attribute
  attribute :other_attribute
end

class OtherSchema
  include Schema

  attribute :some_attribute
  attribute :yet_another_attribute
end

control_schema = SomeSchema.new
compare_schema = OtherSchema.new

assert_raises(Schema::Compare::Comparison::Error) do
  # Raises an error, since compare_schema doesn't have :other_attribute
  Schema::Compare.(control_schema, compare_schema)
end
```

This error is entirely sensible -- when comparing different schema classes, the user should specify a list of common attributes to compare (unless the two schema classes share the same attributes by coincidence). So, if the schema being compared only has `some_attribute`, a user of Schema::Compare would need to pass in `[:some_attribute]` to the `attribute_names` parameter when actuating a comparison:

```ruby
refute_raises(Schema::Compare::Comparison::Error) do
  # Does not raise an error, because :other_attribute isn't considered, and both schemas have :some_attribute
  Schema::Compare.(control_schema, compare_schema, [:some_attribute])
end
```

However, since schema equality is implemented in terms of schema comparison, there is a problem when comparing two different schemas with different attributes: `Schema#==` should return false in this case, but because `Schema#==` calls `Schema::Compare.()`, it raises a `Schema::Compare::Comparison::Error` instead. This is problematic, for instance, when exercising the writer substitute when a batch of messages of different schemas have been written:

```ruby
class SomeMessage
  include Messaging::Message

  attribute :some_attribute
end

class OtherMessage
  include Messaging::Message

  attribute :other_attribute
end

message_1 = SomeMessage.build(:some_attribute => 'some-value')
message_2 = OtherMessage.build(:other_attribute => 'other-value')

write = Messaging::Write::Substitute.build
write.([message_1, message_2], "someStream-123")

# Without this PR, this incorrectly raises a Schema::Compare::Comparison::Error due to message_2 lacking :some_attribute
write.written?(message_2)
```

This PR adds a guard to `Schema#==` to return false prior to making a comparison if `ignore_class` isn't activated. The behavior is the same as before if `ignore_class` is activated. I'm not able to come up with a better approach without rethinking the whole design of `Schema::Compare::Comparison`, which probably should be done as a group effort.