### PR TITLE
Attribute name is added to type mismatch errors

### DIFF
--- a/lib/schema/schema.rb
+++ b/lib/schema/schema.rb
@@ -50,9 +50,9 @@ module Schema
         check = proc do |val|
           unless val.nil?
             if strict
-              raise Schema::Attribute::TypeError, "#{val.inspect} is not an instance of #{type.name}" unless val.instance_of? type
+              raise Schema::Attribute::TypeError, "#{val.inspect} assigned to #{attribute_name} is not an instance of #{type.name}" unless val.instance_of? type
             else
-              raise Schema::Attribute::TypeError, "#{val.inspect} is not a kind of #{type.name}" unless val.is_a? type
+              raise Schema::Attribute::TypeError, "#{val.inspect} assigned to #{attribute_name} is not a kind of #{type.name}" unless val.is_a? type
             end
           end
         end


### PR DESCRIPTION
Related to issue #11.

The PR was simple to make.  Feel free to ignore if it doesn't match the project's direction.

I didn't see any tests checking the specific content of the error messages, so I didn't modify or add any tests.